### PR TITLE
Update README to use correct parameters for Client.instanceFor method

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const username = 'concourse-client'
 const password = 'super-secret-password'
 const teamName = 'main'
 
-const client = Client.instanceFor(url, username, password, teamName)
+const client = Client.instanceFor({ url, username, password, teamName })
 ```
 
 Note, `teamName` only needs to be provided for a Concourse CI deployment with a 


### PR DESCRIPTION
The README states that the `instanceFor` method accepts strings as parameters

`const client = Client.instanceFor(url, username, password, teamName)`
but the code accepts an object.  Therefore throwing an error when validating the `apiUrl`

https://github.com/infrablocks/concourse.js/blob/4c7e1e84117f2b11eef06468de721e28a72f4c89/src/Client.js#L32-L42

This change just updates the README to reflect what should be passed in